### PR TITLE
Add clear button functionality for Gantt chart data

### DIFF
--- a/main.js
+++ b/main.js
@@ -112,6 +112,16 @@ try {
         { field: 'Predecessor', headerText: 'Predecessores', width: 120, textAlign: 'Left', allowEditing: true, clipMode: 'EllipsisWithTooltip',
           valueAccessor: displayPredecessors }
     ],
+    toolbarClick: function(args) {
+        if (args && args.item && args.item.id === 'Gantt_Clear') {
+            try {
+                ganttChart.dataSource = [];
+                ganttChart.refresh();
+            } catch (e) {
+                console.error('Falha ao limpar o dataSource:', e);
+            }
+        }
+    },
     labelSettings: {
         leftLabel: 'TaskName',
         rightLabel: 'Progress',


### PR DESCRIPTION
## Purpose
The user requested a button to clear the data source of the Gantt chart. This feature allows users to quickly reset the chart by removing all existing data.

## Code changes
- Added `toolbarClick` event handler to the Gantt chart configuration
- Implemented logic to detect clicks on the 'Gantt_Clear' toolbar button
- Added functionality to clear the data source by setting it to an empty array
- Included error handling with console logging for any failures during the clear operation
- Added chart refresh after clearing to update the display

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8b84e72de3074722b87158aac7c204d2/nova-garden)

👀 [Preview Link](https://8b84e72de3074722b87158aac7c204d2-nova-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8b84e72de3074722b87158aac7c204d2</projectId>-->
<!--<branchName>nova-garden</branchName>-->